### PR TITLE
readchar 4.2.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,11 +30,11 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v tests/linux  # [linux]
+    - pytest -s -v tests/linux  # [linux]
     - pytest -v tests/windows  # [win]
   requires:
     - pip
-    - pytest>=6.0
+    - pytest >=6.0
 
 about:
   home: https://github.com/magmax/python-readchar

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,34 +1,40 @@
 {% set name = "readchar" %}
-{% set version = "4.0.5" %}
+{% set version = "4.2.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/readchar-{{ version }}.tar.gz
-  sha256: 08a456c2d7c1888cde3f4688b542621b676eb38cd6cfed7eb6cb2e2905ddc826
+  url: https://github.com/magmax/python-{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 2c3a6eb9a41c228ab8324b7abaff7a91ec5c8c450b5b81f0853b6f0855b9e692
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<38]
 
 requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
+    - setuptools >=61.0
   run:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - readchar
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -v tests/linux  # [linux]
+    - pytest -v tests/windows  # [win]
   requires:
     - pip
+    - pytest>=6.0
 
 about:
   home: https://github.com/magmax/python-readchar


### PR DESCRIPTION
readchar 4.2.1 

**Destination channel:** Defaults

### Links

- [PKG-10223]
- dev_url:        https://github.com/magmax/python-readchar/tree/v4.2.1
- conda_forge:    https://github.com/conda-forge/readchar-feedstock
- pypi:           https://pypi.org/project/readchar/4.2.1
- pypi inspector: https://inspector.pypi.io/project/readchar/4.2.1

### Explanation of changes:

- new version number


[PKG-10223]: https://anaconda.atlassian.net/browse/PKG-10223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ